### PR TITLE
Added filename to mediaType detection

### DIFF
--- a/src/main/java/edu/kit/datamanager/repo/service/impl/NoneDataVersioningService.java
+++ b/src/main/java/edu/kit/datamanager/repo/service/impl/NoneDataVersioningService.java
@@ -127,7 +127,7 @@ public class NoneDataVersioningService implements IRepoVersioningService{
           AutoDetectParser parser = new AutoDetectParser();
           Detector detector = parser.getDetector();
           Metadata md1 = new Metadata();
-          //md1.add(Metadata.RESOURCE_NAME_KEY, contentInfo.getFilename());
+          md1.add(Metadata.RESOURCE_NAME_KEY, destination.getFileName().toString());
           org.apache.tika.mime.MediaType mediaType = detector.detect(bis, md1);
           map.put("mediaType", mediaType.toString());
           logger.trace("Assigned media type {} to content information.", map.get("mediaType"));

--- a/src/main/java/edu/kit/datamanager/repo/service/impl/SimpleDataVersioningService.java
+++ b/src/main/java/edu/kit/datamanager/repo/service/impl/SimpleDataVersioningService.java
@@ -101,7 +101,7 @@ public class SimpleDataVersioningService implements IRepoVersioningService{
           AutoDetectParser parser = new AutoDetectParser();
           Detector detector = parser.getDetector();
           Metadata md1 = new Metadata();
-          //md1.add(Metadata.RESOURCE_NAME_KEY, contentInfo.getFilename());
+          md1.add(Metadata.RESOURCE_NAME_KEY, destination.getFileName().toString());
           org.apache.tika.mime.MediaType mediaType = detector.detect(bis, md1);
           map.put("mediaType", mediaType.toString());
           logger.trace("Assigned media type {} to content information.", map.get("mediaType"));


### PR DESCRIPTION
 The change is intended to provide a more specific detection of mediaType in versioning service implementations. E.g., given a file metadata.json results in mediaType text/plain without this change, whereas with provided filename, the extension is used to obtain more specific results, i.e., application/json